### PR TITLE
Send `Entry` directly through channel

### DIFF
--- a/src/fluentd.rs
+++ b/src/fluentd.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 /// An array representation of pairs of time and record, used in Forward mode.
 ///
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Entry {
     pub time: u64,
-    pub record: BTreeMap<String, ByteBuf>,
+    pub record: HashMap<String, ByteBuf>,
 }
 
 /// A series of events packed into a single message.
@@ -29,5 +29,5 @@ pub struct Entry {
 pub struct ForwardMode {
     pub tag: String,
     pub entries: Vec<Entry>,
-    pub option: Option<BTreeMap<String, String>>,
+    pub option: Option<HashMap<String, String>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,35 +5,3 @@
 
 pub mod fluentd;
 pub mod kafka;
-
-use serde::{Deserialize, Serialize};
-
-/// A raw event with an identifier.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct Event<T> {
-    /// Identifier.
-    ///
-    /// Allows any 64-bit integer. If the source is [`fluentd::ForwardMode`],
-    /// this is a copy of the [`fluentd::Entry::time`] of the corresponding
-    /// elements in [`fluentd::ForwardMode::entries`].
-    pub id: u64,
-
-    /// Raw data.
-    ///
-    /// The most common type for this field is `Vec<u8>` that represents an
-    /// event as a sequence of bytes.
-    pub data: Vec<T>,
-}
-
-impl<T> Event<T>
-where
-    T: Copy,
-{
-    /// Creates an event from an identifier and raw data.
-    pub fn from_slice(id: u64, slice: &[T]) -> Self {
-        Self {
-            id,
-            data: slice.to_vec(),
-        }
-    }
-}


### PR DESCRIPTION
Converting `Entry` into another type is better to be done in the
application, leaving this crate for I/O only.