### PR TITLE
Add ACK channel to commit Kafka messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macOS-10.14]
-        rust: [1.32.0, stable]
+        rust: [1.34.0, stable]
 
     steps:
     - name: Install Rust


### PR DESCRIPTION
A message is consumed when an ack message for the last `Entry` in `ForwardMode` is received, and committed when there is no incoming ack message in the channel.

Requires Rust>=1.34 to use `TryInto`.