### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macOS-10.14]
-        rust: [1.37.0, stable]
+        rust: [stable, 1.37.0]
 
     steps:
     - name: Install Rust

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ applications. It allows to collect events from various sources, distribute them
 to one or more event processors, and optionally collect the processing results
 to send them to storage or other event processors.
 
+[![Coverage Status](https://codecov.io/gh/petabi/eventio/branch/master/graphs/badge.svg)](https://codecov.io/gh/petabi/eventio)
+
 ## Requirements
 
 * Rust ≥ 1.37


### PR DESCRIPTION
* Run stable first so that its result is available on the first page of the result.
* Display the code coverage badge in README.
