### PR TITLE
Relax trait requirements for `split`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2021-08-26
+
+### Changes
+
+- `split` requires `Clone`, rather than `Copy` for `initialize`, `fold`, and
+  `finalize`.
+
 ## [0.6.0] - 2021-06-10
 
 ### Changed
@@ -88,6 +95,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Kafka input/output and an example of their usage.
 
+[0.6.1]: https://github.com/petabi/eventio/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/petabi/eventio/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/petabi/eventio/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/petabi/eventio/compare/0.4.0...0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventio"
-version = "0.6.0"
+version = "0.6.1"
 description = "A collection of event I/O processors for event-processing applications."
 readme = "README.md"
 documentation = "https://docs.rs/eventio"

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,9 +14,9 @@ where
     D: 'static + Send + Event,
     <D as Event>::Ack: Into<A>,
     A: 'static + Send,
-    I: 'static + Fn() -> S + Copy + Send,
-    O: 'static + Fn(S, &D) -> S + Copy + Send,
-    F: 'static + Fn(S) -> R + Copy + Send,
+    I: 'static + Fn() -> S + Clone + Send,
+    O: 'static + Fn(S, &D) -> S + Clone + Send,
+    F: 'static + Fn(S) -> R + Clone + Send,
     R: 'static + Send,
 {
     let mut workers = Vec::new();
@@ -24,6 +24,9 @@ where
     for _ in 0..nthreads {
         let rx = rx.clone();
         let tx = tx.clone();
+        let initialize = initialize.clone();
+        let fold = fold.clone();
+        let finalize = finalize.clone();
         workers.push(thread::spawn(move || {
             let mut s = initialize();
             while let Ok(ev) = rx.recv() {


### PR DESCRIPTION
`split` requires `Clone`, rather than `Copy` for `initialize`, `fold`, and `finalize`.